### PR TITLE
Navigation with attached blocks (directly around agent)

### DIFF
--- a/agents/helpers/agent.py
+++ b/agents/helpers/agent.py
@@ -343,31 +343,6 @@ class DStarLite(object):
         # Create initial path to goal
         self.compute_shortest_path()
 
-    def old_transition_cost(self, from_node, to_node):
-        """
-        Returns the cost of the node transition.
-
-        parameters
-        ----------
-        from_node: tuple
-            x and y coordinate of first node
-        to_node: tuple
-            x and y coordinate of second node
-        """
-
-        for node in [from_node, to_node]:
-            if node in self.beliefs.nodes and \
-                self.beliefs.nodes[node]._is_thing(self.beliefs.step,
-                                                   self.beliefs.get_current(
-                                                    self.agent_id).location):
-                return float('inf')
-
-        if to_node in self.beliefs.nodes and \
-                self.beliefs.nodes[to_node]._is_obstacle():
-            return self.obstacle_cost
-
-        return 1
-
     def transition_cost(self, from_node, to_node):
         """
         Returns the cost of the node transition.

--- a/agents/helpers/graph.py
+++ b/agents/helpers/graph.py
@@ -242,7 +242,8 @@ class Node(object):
             return True
         return False
 
-    def _is_thing(self, step, agent_location, things=['block', 'entity']):
+    def _is_thing(self, step, agent_location, attached,
+                  things=['block', 'entity']):
         """
         Determine if a node is a given thing.
         By default looking for blocks and entities.
@@ -252,6 +253,8 @@ class Node(object):
             Current game step.
         agent_location: (int, int)
             The location of the agent itself.
+        attached: list of tuples
+            The location of the blocks attached to the agent.
         things: list of str
             List of things to include from {block, entity, dispenser, marker}.
         """
@@ -259,57 +262,15 @@ class Node(object):
         if agent_location == self.location:
             return False
 
-        # check for entities
+        if self.location in attached:
+            return False
+
+        # check for things
         loc_things = self.get_things(step)
         for thing in loc_things:
             if thing[0] in things:
                 return True
         return False
-
-
-# class ExpNode(object):
-#     def __init__(self, location, terrain='empty', things={},
-#                  surr_obstacles=0):
-#         """
-#         Initialise the node and create attribute with default values.
-#         Terrain and step get combined into a tuple for easier use
-
-#         Arguments
-#         ---------
-#         location: tuple(int, int)
-#             A tuple containing the x, y coordinate of the node relative to the
-#             graph's initial node.
-#         terrain: str
-#             The type of terrain (empty, obstacle, goal).
-#         things: {step:thing}
-#             A dictionary containing a list of things (value) in the node
-#             (entities, blocks, dispensers, markers) on a certain step (key).
-#         """
-#         self.location = location
-#         self.terrain = terrain
-#         self.surr_obstacles = surr_obstacles
-#         # if things == {}:
-#         #     self.things = {}
-#         # else:
-#         #     self.things = things
-
-#     def set_terrain(self, terrain):
-#         self.terrain = terrain
-
-#     def _is_obstacle(self):
-#         """
-#         Determine if a node is an obstacle block.
-#         Parameters
-#         ---------
-#         step: int
-#             Current game step.
-#         agent_location: (int, int)
-#             The location of the agent itself.
-#         """
-#         # check for obstacles
-#         if self.terrain == 'obstacle' or self.surr_obstacles:
-#             return True
-#         return False
 
 
 class Graph(object):

--- a/agents/helpers/graph.py
+++ b/agents/helpers/graph.py
@@ -725,53 +725,6 @@ class Graph(object):
         for node in self.nodes:
             self.add_neighbours(self.nodes[node])
 
-    def print_map(self, agent_id):
-        curr_x, curr_y = self.get_current(agent_id).location
-
-        print_res = ''
-
-        min_x = min(self.nodes.keys(), key=lambda x: x[0])[0]
-        max_x = max(self.nodes.keys(), key=lambda x: x[0])[0]
-        min_y = min(self.nodes.keys(), key=lambda x: x[1])[1]
-        max_y = max(self.nodes.keys(), key=lambda x: x[1])[1]
-
-        for y in range(min_y, max_y + 1):
-            for x in range(min_x, max_x + 1):
-                if (x, y) == (curr_x, curr_y):
-                    print_res += f"{'A' + str(agent_id):<3}"
-                elif (x, y) == (0, 0):
-                    print_res += f"{'O':<3}"
-                elif (x, y) in self.nodes:
-                    things = self.nodes[(x, y)].get_things(step=self.step)
-                    terrain = self.nodes[(x, y)].get_terrain()[0]
-
-                    print_tmp = ''
-                    for (thing, detail) in things:
-                        if thing == 'entity' and (x, y) != (curr_x, curr_y):
-                            print_tmp = f"{'A?':<3}"
-                        elif thing == 'block' and not print_tmp:
-                            print_tmp = f"{detail:<3}"
-                        elif thing == 'dispenser' and not print_tmp:
-                            print_tmp = f"{'d' + detail[1]:<3}"
-                        elif thing == 'marker' and not print_tmp:
-                            print_tmp = f"{'M':<3}"
-                        elif thing == 'taskboard' and not print_tmp:
-                            print_tmp = f"{'T':<3}"
-                    print_res += print_tmp
-
-                    if not print_tmp:
-                        if terrain == 'empty':
-                            print_res += f"{'.':<3}"
-                        elif terrain == 'obstacle':
-                            print_res += f"{'#':<3}"
-                        elif terrain == 'goal':
-                            print_res += f"{'G':<3}"
-                else:
-                    print_res += f"{'':<3}"
-            print_res += '\n'
-
-        print(print_res)
-
 
 def agent_moved(msg):
     """

--- a/agents/superAgent.py
+++ b/agents/superAgent.py
@@ -25,7 +25,7 @@ class SuperAgent(*AGENTS, BDIAgent):
         while True:
             # Receive a message.
             msg = self.receive_msg()
-            # time.sleep(0.5)  # uncomment to add delay per step in agent.
+            time.sleep(0.6)  # uncomment to add delay per step in agent.
 
             if msg:
                 # Parse the response.

--- a/main.py
+++ b/main.py
@@ -4,6 +4,19 @@ import json
 from agents import SuperAgent
 
 
+def main():
+
+    teamSize = get_teamSize()
+
+    # In case teamSize is returned and not None, start up the agents
+    if teamSize:
+        a_list = []
+
+        for i in range(1, teamSize + 1):
+            a_list.append(SuperAgent(f"agentA{i}", "1"))
+            a_list[-1].start()
+
+
 def get_teamSize():
     """
     Returns the configuration of the server as
@@ -37,7 +50,7 @@ def get_teamSize():
 
     msg = sock.recv(65536).decode().split("\0")[0]
     msg = json.loads(msg)
-    print(msg)
+    # print(msg)
 
     # If message is received, parse it and return it otherwise return None
     if len(msg) > 1:
@@ -53,20 +66,6 @@ def get_teamSize():
         return None
 
     sock.close()
-
-
-def main():
-
-    teamSize = get_teamSize()
-
-    # In case teamSize is returned and not None, start up the agents
-    if teamSize:
-
-        a_list = []
-
-        for i in range(1, teamSize + 1):
-            a_list.append(SuperAgent(f"agentA{i}", "1"))
-            a_list[-1].start()
 
 
 if __name__ == "__main__":

--- a/tools/create_environment.py
+++ b/tools/create_environment.py
@@ -41,7 +41,8 @@ def main():
         return
 
     # TODO: Add tasks and steps into customMap.txt and parse it nicely
-    tasks = {'task1': (100, [(1, 0, 'b0')]), 'task2': (150, [(0, 1, 'b1')])}
+    # tasks = {'task1': (100, [(1, 0, 'b0')]), 'task2': (150, [(0, 1, 'b1')])}
+    tasks = {'task2': (150, [(0, 1, 'b1')])}
     steps = 300
     fast_mode = True
     taskboards = 1


### PR DESCRIPTION
Navigation with blocks that are directly attached to the agent has been implemented. As of now, every node in an agents belief keep track of how many obstacles are directly around them. If a given empty node has one or more obstacles around, the agent will not navigate there with blocks attached.

Moreover, Agents do not use clear actions in navigation when blocks are attached, as this is a lot less efficient, and a lot more complex.