### PR TITLE
Bugfix: forgot () after calling current_node

### DIFF
--- a/agents/helpers/agent.py
+++ b/agents/helpers/agent.py
@@ -97,7 +97,7 @@ class Agent(Server):
         """
         Returns the node coordinates on which the agent is currently located
         """
-        return self.current_node.location
+        return self.current_node().location
 
     def quit_nav(self):
         """


### PR DESCRIPTION
Forgot to call `current_node` function with brackets in
`current_location`. This fixes that.